### PR TITLE
fix typo in geospatial docs

### DIFF
--- a/docs/0.211/_sources/functions/geospatial.txt
+++ b/docs/0.211/_sources/functions/geospatial.txt
@@ -77,7 +77,7 @@ Relationship Tests
 .. function:: ST_Intersects(Geometry, Geometry) -> boolean
 
     Returns ``true`` if the given geometries spatially intersect in two dimensions
-    (share any portion of space) and ``false`` if they don not (they are disjoint).
+    (share any portion of space) and ``false`` if they do not (they are disjoint).
 
 .. function:: ST_Overlaps(Geometry, Geometry) -> boolean
 


### PR DESCRIPTION
there isn't a contributing guide, i have no idea if this is the right file to fix this in (current version, source).