### PR TITLE
Correct the AWS product names

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -504,7 +504,7 @@ try (Connection connection =
             <h4>Amazon Athena</h4>
             <dl>
                 <dt>Website</dt>
-                <dd><a href="https://aws.amazon.com/athena/">Athena</a></dd>
+                <dd><a href="https://aws.amazon.com/athena/">Amazon Athena</a></dd>
                 <dt>Maintainer</dt>
                 <dd><a href="https://aws.amazon.com/">Amazon Web Services</a></dd>
                 <dd>
@@ -524,7 +524,7 @@ try (Connection connection =
         </div>
 
        <div class="item">
-           <h4>Amazon Elastic MapReduce</h4>
+           <h4>Amazon EMR</h4>
            <dl>
                <dt>Website</dt>
                <dd><a href="https://aws.amazon.com/emr/">Amazon EMR</a></dd>
@@ -532,7 +532,7 @@ try (Connection connection =
                <dd><a href="https://aws.amazon.com/">Amazon Web Services</a></dd>
                <dd>
                    <p>
-                       Amazon Elastic MapReduce (EMR) provides a managed Hadoop framework that makes it easy, fast, and cost-effective
+                       Amazon EMR provides a managed Hadoop framework that makes it easy, fast, and cost-effective
                        to process vast amounts of data across dynamically scalable Amazon EC2 instances. With EMR, you can launch a
                        large Presto cluster in minutes. You don't need to worry about node provisioning, cluster setup or tuning.
                    <p/>


### PR DESCRIPTION
Use EMR Instead of Elastic MapReduce, which is a legacy name which is not used anymore