### PR TITLE
Remove quick links on landing page, link to Slack instead of IRC

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -121,21 +121,11 @@
     </div>
 
     <div class="rightcol">
-        <h3>Quick links</h3>
-        <ul>
-            <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Documentation</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="community.html">Community</a></li>
-            <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">Source</a></li>
-        </ul>
         <h3>Community</h3>
         <ul>
             <li><a href="https://groups.google.com/group/presto-users">presto-users group</a></li>
             <li><a href="https://github.com/facebook/presto/issues">Report an issue</a></li>
-            <li><a href="https://webchat.freenode.net/?channels=prestodb"><tt>#prestodb</tt> IRC on freenode</a></li>
+            <li><a href="https://prestodb.slack.com">Slack</a></li>
             <li><a href="https://www.facebook.com/prestodb">Facebook</a> <div class="fb-like" data-href="https://www.facebook.com/prestodb" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></li>
         </ul>
 


### PR DESCRIPTION
Fixes: #34