### PR TITLE
elasticsearch.scroll-timeout example correction

### DIFF
--- a/website/static/docs/0.223/connector/elasticsearch.html
+++ b/website/static/docs/0.223/connector/elasticsearch.html
@@ -80,7 +80,7 @@ replacing the properties as appropriate:</p>
 elasticsearch.default-schema=default
 elasticsearch.table-description-directory=etc/elasticsearch/
 elasticsearch.scroll-size=1000
-elasticsearch.scroll-timeout=60000
+elasticsearch.scroll-timeout=60000ms
 elasticsearch.request-timeout=2s
 elasticsearch.max-request-retries=5
 elasticsearch.max-request-retry-time=10s


### PR DESCRIPTION
Elasticsearch Scroll Timeout example config in documentation is not in airlift.units.Duration format.