### PR TITLE
Update links to docs and GitHub

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -61,12 +61,12 @@ const siteConfig = {
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     {href: prestoBaseUrl + 'overview.html', label: 'OVERVIEW'},
-    {href: prestoBaseUrl + 'docs/current', label: 'DOCS'},
+    {href: 'https://prestodb.github.io/docs/current', label: 'DOCS'},
     {href: prestoBaseUrl + 'index.html', label: 'BLOG'},
     {href: prestoBaseUrl + 'faq.html', label: 'FAQ'},
     {href: prestoBaseUrl + 'community.html', label: 'COMMUNITY'},
     {href: prestoBaseUrl + 'resources.html', label: 'RESOURCES'},
-    {href: 'https://github.com/facebook/presto', label: 'GITHUB'},
+    {href: 'https://github.com/prestodb/presto', label: 'GITHUB'},
   ],
   // headerLinks: [
   //   {doc: 'overview', label: 'Overview'},

--- a/website/static/community.html
+++ b/website/static/community.html
@@ -18,12 +18,12 @@
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
             <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Docs</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">GitHub</a>
+            <li><a href="https://github.com/prestodb/presto">GitHub</a>
         </ul>
     </nav>
 </header>
@@ -50,14 +50,14 @@
 
         <p>
             If you find an issue with Presto, please
-            <a href="https://github.com/facebook/presto/issues/new">report</a> it.
+            <a href="https://github.com/prestodb/presto/issues/new">report</a> it.
         </p>
 
         <h2>Contributing</h2>
 
         <p>
             You can also contribute fixes and new features as
-            <a href="https://github.com/facebook/presto/pulls">pull requests</a>.
+            <a href="https://github.com/prestodb/presto/pulls">pull requests</a>.
             You will need to sign a
             <a href="https://developers.facebook.com/opensource/cla">Contributor License Agreement</a>
             ("CLA") before it can be accepted into the repository.

--- a/website/static/download.html
+++ b/website/static/download.html
@@ -29,12 +29,12 @@
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
             <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Docs</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">GitHub</a>
+            <li><a href="https://github.com/prestodb/presto">GitHub</a>
         </ul>
     </nav>
 </header>

--- a/website/static/faq.html
+++ b/website/static/faq.html
@@ -18,12 +18,12 @@
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
             <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Docs</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">GitHub</a>
+            <li><a href="https://github.com/prestodb/presto">GitHub</a>
         </ul>
     </nav>
 </header>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -28,12 +28,12 @@
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
             <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Docs</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">GitHub</a>
+            <li><a href="https://github.com/prestodb/presto">GitHub</a>
         </ul>
     </nav>
 </header>
@@ -166,7 +166,7 @@
       <h3>Community</h3>
         <ul>
             <li><a href="https://groups.google.com/group/presto-users">presto-users group</a></li>
-            <li><a href="https://github.com/facebook/presto/issues">Report an issue</a></li>
+            <li><a href="https://github.com/prestodb/presto/issues">Report an issue</a></li>
             <li><a href="https://join.slack.com/t/prestodb/shared_invite/enQtNTQ3NjU2MTYyNDA2LTYyOTg3MzUyMWE1YTI3Njc5YjgxZjNiYTgxODAzYjI5YWMwYWE0MTZjYWFhNGMwNjczYjI3N2JhM2ExMGJlMWM">Slack</a></li>
             <li><a href="https://www.facebook.com/prestodb">Facebook</a> <div class="fb-like" data-href="https://www.facebook.com/prestodb" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></li>
             <li><a href="https://twitter.com/prestodb">Twitter</a></li>
@@ -175,7 +175,7 @@
         <h3>License</h3>
         <ul>
             <li><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2</a></li>
-            <li><a href="https://github.com/facebook/presto/blob/master/CONTRIBUTING.md">Contributing</a></li>
+            <li><a href="https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md">Contributing</a></li>
         </ul>
     </div>
 </div>

--- a/website/static/overview.html
+++ b/website/static/overview.html
@@ -18,12 +18,12 @@
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
             <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Docs</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">GitHub</a>
+            <li><a href="https://github.com/prestodb/presto">GitHub</a>
         </ul>
     </nav>
 </header>

--- a/website/static/resources.html
+++ b/website/static/resources.html
@@ -18,12 +18,12 @@
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
             <li><a href="overview.html">Overview</a></li>
-            <li><a href="docs/current/">Docs</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/facebook/presto">GitHub</a>
+            <li><a href="https://github.com/prestodb/presto">GitHub</a>
         </ul>
     </nav>
 </header>
@@ -252,7 +252,7 @@ presto-admin connector add connector-name
                 <dt>Project</dt>
                 <dd><a href="docs/current/installation/jdbc.html">Presto</a></dd>
                 <dt>Maintained by</dt>
-                <dd><a href="https://github.com/facebook/presto">Presto Team</a></dd>
+                <dd><a href="https://github.com/prestodb/presto">Presto Team</a></dd>
                 <dt>Description</dt>
                 <dd>JDBC driver for Presto.</dd>
                 <dt>Example</dt>


### PR DESCRIPTION
The header docs link was not resolving, and in various places the GitHub repos
still pointed to github.com/facebook/presto.  These have been updated to point
to the current locations.

Signed-off-by: Brian Warner <brian@bdwarner.com>