### PR TITLE
Add a join page and change GitHub to octocat logo

### DIFF
--- a/website/static/community.html
+++ b/website/static/community.html
@@ -23,7 +23,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/community.html
+++ b/website/static/community.html
@@ -23,7 +23,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/prestodb/presto">GitHub</a>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>
 </header>

--- a/website/static/download.html
+++ b/website/static/download.html
@@ -34,7 +34,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/prestodb/presto">GitHub</a>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>
 </header>

--- a/website/static/download.html
+++ b/website/static/download.html
@@ -34,7 +34,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/faq.html
+++ b/website/static/faq.html
@@ -23,7 +23,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/faq.html
+++ b/website/static/faq.html
@@ -23,7 +23,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/prestodb/presto">GitHub</a>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>
 </header>
@@ -158,7 +159,7 @@
     </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2016, Presto Foundation</div>
+<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
 
 </body>
 </html>

--- a/website/static/img/github.svg
+++ b/website/static/img/github.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="github.svg"
+   inkscape:version="1.0beta1 (32d4812, 2019-09-19)"
+   id="svg1602"
+   version="1.1"
+   viewBox="0 0 11.493147 11.209467"
+   height="11.209467mm"
+   width="11.493147mm">
+  <defs
+     id="defs1596" />
+  <sodipodi:namedview
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="1.5228867"
+     inkscape:cx="41.246754"
+     inkscape:zoom="3.4056975"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata1599">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-87.23557,-181.11551)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       style="opacity:1;stop-opacity:1"
+       id="g1063"
+       transform="matrix(0.35277777,0,0,-0.35277777,92.981614,181.11551)">
+      <path
+         d="m 0,0 c -8.995,0 -16.288,-7.293 -16.288,-16.29 0,-7.197 4.667,-13.302 11.14,-15.457 0.815,-0.149 1.112,0.354 1.112,0.786 0,0.386 -0.014,1.411 -0.022,2.77 -4.531,-0.984 -5.487,2.184 -5.487,2.184 -0.741,1.882 -1.809,2.383 -1.809,2.383 -1.479,1.01 0.112,0.99 0.112,0.99 1.635,-0.115 2.495,-1.679 2.495,-1.679 1.453,-2.489 3.813,-1.77 4.741,-1.353 0.148,1.052 0.568,1.77 1.034,2.177 -3.617,0.411 -7.42,1.809 -7.42,8.051 0,1.778 0.635,3.232 1.677,4.371 -0.168,0.412 -0.727,2.068 0.159,4.311 0,0 1.368,0.438 4.48,-1.67 1.299,0.362 2.693,0.542 4.078,0.548 1.383,-0.006 2.777,-0.186 4.078,-0.548 3.11,2.108 4.475,1.67 4.475,1.67 0.889,-2.243 0.33,-3.899 0.162,-4.311 1.044,-1.139 1.675,-2.593 1.675,-4.371 0,-6.258 -3.809,-7.635 -7.438,-8.038 0.585,-0.503 1.106,-1.497 1.106,-3.017 0,-2.177 -0.02,-3.934 -0.02,-4.468 0,-0.436 0.293,-0.943 1.12,-0.784 6.468,2.159 11.131,8.26 11.131,15.455 C 16.291,-7.293 8.997,0 0,0"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         id="path1065"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -33,7 +33,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/prestodb/presto">GitHub</a>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>
 </header>
@@ -71,12 +72,19 @@
         </p>
 
         <p>
-             The community owned and driven Presto project is supported by the
-             Presto Foundation, an independent nonprofit organization
-             with open and neutral governance, hosted under the
-             <a href="https://www.linuxfoundation.org/">Linux Foundation®</a>.
-             Learn more about the Presto Foundation on the
-             <a href="https://www.linuxfoundation.org/uncategorized/2019/09/facebook-uber-twitter-and-alibaba-form-presto-foundation-to-tackle-distributed-data-processing-at-scale/">Linux Foundation's website</a>.
+            The community owned and driven Presto project is supported by the
+            <a href="./join.html">Presto Foundation</a>, an independent
+            nonprofit organization with open and neutral governance, hosted
+            under the <a href="https://www.linuxfoundation.org/">Linux
+            Foundation®</a>.
+        </p>
+
+        <p>
+            Learn more about the Presto's
+            <a href="https://www.linuxfoundation.org/uncategorized/2019/09/facebook-uber-twitter-and-alibaba-form-presto-foundation-to-tackle-distributed-data-processing-at-scale/">move
+            to the Linux Foundation</a>, and learn how to
+            <a href="./join.html">become a member of the Presto Foundation
+            today</a>.
         </p>
 
         <h2>What can it do?</h2>
@@ -130,6 +138,19 @@
             </p>
             <small>Fred Wulff, Software Engineer, Dropbox</small>
         </blockquote>
+
+        <h2>What is the Presto Foundation?</h2>
+
+        <p>
+            The Presto Foundation is the non-profit established to support the
+            developer and community processes for the Presto open source
+            project. Hosted under the auspices of <a href="https://linuxfoundation.org">the Linux Foundation</a>,
+            the Presto Foundation is governed openly and transparently.
+        </p>
+        <p>
+            If you share our vision for Presto and are ready to provide
+            financial support for the community development process, please
+            <a href="/join.html">join us!</a>
     </div>
 
     <div class="rightcol">
@@ -165,6 +186,7 @@
       </script>
       <h3>Community</h3>
         <ul>
+            <li><a href="join">Join the Presto Foundation</a></li>
             <li><a href="https://groups.google.com/group/presto-users">presto-users group</a></li>
             <li><a href="https://github.com/prestodb/presto/issues">Report an issue</a></li>
             <li><a href="https://join.slack.com/t/prestodb/shared_invite/enQtNTQ3NjU2MTYyNDA2LTYyOTg3MzUyMWE1YTI3Njc5YjgxZjNiYTgxODAzYjI5YWMwYWE0MTZjYWFhNGMwNjczYjI3N2JhM2ExMGJlMWM">Slack</a></li>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -33,7 +33,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/join.html
+++ b/website/static/join.html
@@ -23,7 +23,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/join.html
+++ b/website/static/join.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Presto | Join the Presto Foundation</title>
+    <link rel="stylesheet" href="static/presto.css" type="text/css"/>
+
+    <meta name="viewport" content="width=device-width">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Presto | Join the Presto Foundation">
+    <meta property="og:description" content="Distributed SQL Query Engine for Big Data">
+    <meta property="og:image" content="static/presto-og.png">
+</head>
+<body>
+
+<header class="topbar clearfix">
+    <nav class="width">
+        <a href="."><h1>Presto</h1></a>
+        <ul class="nav">
+            <li><a href="overview.html">Overview</a></li>
+            <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
+            <li><a href="blog/index.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="community.html">Community</a></li>
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
+        </ul>
+    </nav>
+</header>
+
+<header class="hero clearfix">
+    <div class="width">
+        <h1>Join the Presto Foundation</h1>
+    </div>
+</header>
+
+<div class="content homecontent width clearfix">
+    <div class="">
+        <h2 id="about">About the Presto Foundation</h2>
+
+        <h3 id="what-is-the-presto-foundation">What is the Presto Foundation?</h3>
+
+        <p>
+            The Presto Foundation is the organization that oversees the
+            development of the <a href="https://prestodb.io">Presto open source
+            project</a>. Members of the Presto Foundation provide essential
+            financial support for the collaborative development process,
+            including tooling, infrastructure, and community conferences.
+        </p>
+
+        <p>
+            The Presto Foundation <a
+href="https://www.linuxfoundation.org/press-release/2019/09/facebook-uber-twitter-and-alibaba-form-presto-foundation-to-tackle-distributed-data-processing-at-scale/">joined the Linux Foundation</a>
+            in September 2019.
+        </p>
+
+        <h3 id="where-is-the-presto-foundation-hosted">Where is the Presto Foundation hosted?</h3>
+
+        <p>
+            The Presto Foundation is hosted at
+            <a href="https://linuxfoundation.org">the Linux Foundation</a>, the
+            non-profit which hosts the Linux kernel and many other open source
+            projects. Founded in 2000, the Linux Foundation is supported by more
+            than 1,000 members and is the world’s leading home for collaboration
+            on open source software, open standards, open data, and open
+            hardware.
+        </p>
+
+        <h3 id="how-presto-foundation-will-enable-open-governance">How will the
+        Presto Foundation enable neutral governance for Presto?</h3>
+
+        <p>
+            <a href="https://www.facebook.com/notes/facebook-engineering/presto-interacting-with-petabytes-of-data-at-facebook/10151786197628920/">Presto was developed at Facebook</a>
+            in 2012 as a high-performance distributed SQL query engine for large
+            scale data analytics. Presto Foundation will operate under a
+            community governance model with representation from each of the
+            founding members. With this evolution Facebook will be collaborating
+            with the broader ecosystem of users and contributors as one voice in
+            the future of the Foundation.
+        </p>
+
+        <h3 id="governing-body">What are the governing bodies?</h3>
+
+        <p>
+            The Presto Foundation has two main governing bodies: The Governing
+            Board, and the Technical Steering Committee (TSC).
+        </p>
+
+        <p>
+            The <strong>Governing Board</strong> manages the Presto Foundation's
+            funding in support of the Presto open source project. Organizations
+            become members and pay dues, which the Governing Board then
+            allocates. Premier members are entitled to appoint a representative
+            to the Governing Board, and participate directly in funding
+            decisions.
+        </p>
+
+        <p>
+            The <strong>TSC</strong> manages the open source development
+            process, and is responsible for technical oversight of the project.
+            This means continuing the development of Presto as an open source
+            distributed SQL query engine, but also developing documentation,
+            testing, integration, and the creation of artifacts that aid the
+            development process. While the TSC is open for any observer to
+            participate, Any contributor to the open source project may, through
+            time, experience, and wise decision-making, be selected by their
+            peers to be a voting member of the TSC.
+        </p>
+
+        <p>
+            It is important to note that while participaion on the
+            <strong>Governing Board</strong> is limited to Presto Foundation
+            members, anyone may earn the right to lead the <strong>TSC</strong>,
+            regardless of their membership status.
+        <p>
+
+        <h2 id="join">Become a member</h2>
+
+        <h3 id="membership-categories">What are the different types of Presto
+           Foundation membership?</h3>
+
+        <p>
+            The Presto Foundation has two membership levels: Premier, and
+            Associate.
+        </p>
+
+        <p>
+            <strong>Premier members</strong> are entitled to appoint a
+            representative to the Presto Foundation Governing Board and any
+            Presto Foundation committees. In this way, Premier members are
+            directly involved in policy and funding allocation decisions.
+        </p>
+
+        <p>
+            <strong>Associate members</strong> are limited to Associate Members
+            of the Linux Foundation.
+        </p>
+
+        <h3>What are the requirements to become a member?</h3>
+
+        <p>
+            To become a member in the Presto Foundation, an organization must
+            also be a <a href="https://www.linuxfoundation.org/membership/">
+            member of the Linux Foundation</a>. Organizations can become members
+            in the Linux Foundation first, or both simultaneously.
+        </p>
+
+        <p>
+            Premier membership in the Presto Foundation is $10k annually, in
+            addition to Linux Foundation membership.
+        </p>
+
+        <p>
+            There is no cost for Associate membership for qualifying
+            organizations.
+        </p>
+
+        <h3 id="how-to-join">How to join</h3>
+
+        <p>
+            Please complete one of the Presto Foundation application forms:
+        </p>
+
+        <p>
+            <a href="https://na3.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=2a1243e0-61f8-46b6-803c-0351793de9f5&env=na3-eu1&v=2">
+                    We are already a Linux Foundation member, and want to join the Presto Foundation &raquo;</a>
+        <br />
+            <a href="https://na3.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=4e55c0ce-7835-4318-afc0-51fc25865d37&env=na3-eu1&v=2">
+                    We are not yet a Linux Foundation member, and want to join both Foundations &raquo;</a>
+        </p>
+
+        <p>
+            If you have questions about Presto Foundation membership, please
+            reach out to <a href="mailto:bwarner@linuxfoundation.org">Brian
+            Warner &lt;bwarner@linuxfoundation.org&gt;.
+        </p>
+
+</div>
+
+<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+
+</body>
+</html>

--- a/website/static/overview.html
+++ b/website/static/overview.html
@@ -23,7 +23,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/overview.html
+++ b/website/static/overview.html
@@ -23,7 +23,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/prestodb/presto">GitHub</a>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>
 </header>

--- a/website/static/resources.html
+++ b/website/static/resources.html
@@ -23,7 +23,7 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Join</a>
+            <li><a href="join.html">Foundation</a>
             <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>

--- a/website/static/resources.html
+++ b/website/static/resources.html
@@ -23,7 +23,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="https://github.com/prestodb/presto">GitHub</a>
+            <li><a href="join.html">Join</a>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
This commit adds a Presto Foundation page, with descriptions of membership
benefits and links to become a member.

It also includes the octocat logo, as there is no longer room in the header for
the word "GitHub". This commit includes changes to the menus for all existing
static pages, and the blog.

Signed-off-by: Brian Warner <brian@bdwarner.com>