### PR TITLE
Change Overview to About (spacing fix)

### DIFF
--- a/website/static/community.html
+++ b/website/static/community.html
@@ -17,7 +17,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/website/static/download.html
+++ b/website/static/download.html
@@ -28,7 +28,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/website/static/faq.html
+++ b/website/static/faq.html
@@ -17,7 +17,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -27,7 +27,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/website/static/join.html
+++ b/website/static/join.html
@@ -17,7 +17,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/website/static/overview.html
+++ b/website/static/overview.html
@@ -17,7 +17,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/website/static/resources.html
+++ b/website/static/resources.html
@@ -17,7 +17,7 @@
     <nav class="width">
         <a href="."><h1>Presto</h1></a>
         <ul class="nav">
-            <li><a href="overview.html">Overview</a></li>
+            <li><a href="overview.html">About</a></li>
             <li><a href="https://prestodb.github.io/docs/current/">Docs</a></li>
             <li><a href="blog/index.html">Blog</a></li>
             <li><a href="faq.html">FAQ</a></li>


### PR DESCRIPTION
Fix the spacing in the header.  Adding the "Foundation" menu item caused the top
menu bar to overflow.  Changing "Overview" to "About" provided sufficient space
so that the top bar no longer overflows.

Signed-off-by: Brian Warner <brian@bdwarner.com>