### PR TITLE
Update footer to standard LF text

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -24,7 +24,13 @@ class Footer extends React.Component {
   render() {
     return (
       <footer className="nav-footer" id="footer">
-        <section className="copyright">{this.props.config.copyright}</section>
+        <section className="copyright">Copyright &copy; The Presto Foundation.
+All rights reserved. The Linux Foundation has registered trademarks and uses
+trademarks. For a list of trademarks of The Linux Foundation, please see our <a
+href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.
+Linux is a registered trademark of Linus Torvalds. <a
+href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a
+href="http://www.linuxfoundation.org/terms">Terms of Use</a>.</section>
       </footer>
     );
   }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -107,7 +107,8 @@ const siteConfig = {
   */
 
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
-  copyright: `Copyright © 2013-${new Date().getFullYear()} Presto Foundation`,
+//    copyright: ``
+//  copyright: `Copyright © 2013-${new Date().getFullYear()} Presto Foundation`,
 
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks.
@@ -126,7 +127,7 @@ const siteConfig = {
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',
 
-  separateCss: ['static/basic.css', 'static/haiku.css', 'static/presto.css']
+  separateCss: ['static/basic.css', 'static/haiku.css', 'static/presto.css'],
   // Show documentation's last contributor's name.
   // enableUpdateBy: true,
 
@@ -136,6 +137,7 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   //   repoUrl: 'https://github.com/facebook/test-site',
+  stylesheets: ['css/footer.css']
 };
 
 module.exports = siteConfig;

--- a/website/static/community.html
+++ b/website/static/community.html
@@ -97,8 +97,9 @@
     </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
-
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/css/footer.css
+++ b/website/static/css/footer.css
@@ -1,0 +1,5 @@
+#footer .copyright {
+
+    max-width: 1100px;
+    margin: 0 auto;
+}

--- a/website/static/download.html
+++ b/website/static/download.html
@@ -92,7 +92,9 @@
   </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/faq.html
+++ b/website/static/faq.html
@@ -159,7 +159,9 @@
     </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -214,7 +214,9 @@
     </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/join.html
+++ b/website/static/join.html
@@ -181,7 +181,9 @@ href="https://www.linuxfoundation.org/press-release/2019/09/facebook-uber-twitte
 
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/overview.html
+++ b/website/static/overview.html
@@ -126,7 +126,9 @@
     </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/resources.html
+++ b/website/static/resources.html
@@ -474,7 +474,9 @@ try (Connection connection =
 </div>
 </div>
 
-<div class="footer">&copy; Copyright 2013-2019, Presto Foundation</div>
+<div class="footer width">
+Copyright &copy; The Presto Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a>.
+</div>
 
 </body>
 </html>

--- a/website/static/static/presto.css
+++ b/website/static/static/presto.css
@@ -33,6 +33,11 @@ body {
     min-width: inherit;
 }
 
+div.footer {
+    border-top: 1px solid #222;
+    padding: 20px !important;
+}
+
 table {
   border-radius: 5px;
 }


### PR DESCRIPTION
This update replaces the old footer text with standard LF text.  Because the LF
text is longer and includes links, it required some changes to CSS and
(apparently?) a workaround in Docusaurus.

Signed-off-by: Brian Warner <brian@bdwarner.com>