### PR TITLE
change_homepage_banner

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -55,17 +55,13 @@
 </header>
 <div class="clearfix banner-wrap">
   <div class="banner-content">
-    <div>
-      <img src="./img/prestocon-logo-white.svg" class="banner-logo">
-    </div>
-      <div class="banner-info">
-          The health, safety, and wellbeing of our attendees and staff are our highest priority, and after discussions with many community members, we have made the difficult decision to postpone PrestoCon, originally scheduled for March 24, 2020. We’re finalizing the new date and will announce it shortly.
-      </div>
-      <div>
-        <a class="button" href="https://events.linuxfoundation.org/prestocon/attend/novel-coronavirus-update/" target="blank">Postponement Update</a>
-      </div>
+    <div class="banner-info">
+      <h2>Virtual Presto Tech Talk Series</h2>
+      <h3>A new tech talk every month featuring Presto users and their use&nbsp;cases</h3>
+      <a class="button" href="https://www.meetup.com/prestodb" target="_blank">Join the Virtual Meetup Group</a>
     </div>
   </div>
+</div>
 <div class="content homecontent width clearfix">
     <div class="leftcol widecol">
         <h2>What is Presto?</h2>
@@ -202,6 +198,8 @@
             <li><a href="https://groups.google.com/group/presto-users">presto-users group</a></li>
             <li><a href="https://github.com/prestodb/presto/issues">Report an issue</a></li>
             <li><a href="https://join.slack.com/t/prestodb/shared_invite/enQtNTQ3NjU2MTYyNDA2LTYyOTg3MzUyMWE1YTI3Njc5YjgxZjNiYTgxODAzYjI5YWMwYWE0MTZjYWFhNGMwNjczYjI3N2JhM2ExMGJlMWM">Slack</a></li>
+	    <li><a href="https://www.meetup.com/prestodb/">Virtual Meetup Group</a></li>
+	    <li><a href="https://www.linkedin.com/company/presto-foundation/">LinkedIn</a></li>
             <li><a href="https://www.facebook.com/prestodb">Facebook</a> <div class="fb-like" data-href="https://www.facebook.com/prestodb" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></li>
             <li><a href="https://twitter.com/prestodb">Twitter</a></li>
         </ul>

--- a/website/static/static/presto.css
+++ b/website/static/static/presto.css
@@ -359,8 +359,9 @@ code {
 @media(min-width:768px) {
   .banner-content {
     display: flex;
-    text-align: left;
+    text-align: center;
     align-items: center;
+    justify-content: center;
   }
 }
 
@@ -385,4 +386,25 @@ code {
 .banner-info {
   font-size: 1.25em;
   padding: 0 1em;
+}
+
+.banner-info h2 {
+  font-size: 1.4em;
+  color: #fff;
+  text-transform: initial;
+  font-weight: bold;
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin:0;
+}
+
+.banner-info h3 {
+  padding: 0;
+  margin:0;
+  color: #fff;
+}
+
+.mt-3em  {
+    margin-top: 3em;
 }


### PR DESCRIPTION
@aweisberg 

Change homepage banner from PrestoCon postponed to Virtual Meetup. Added links to Virtual Meetup & LinkedIn page under Community section in right hand margin.

Before:
![Screen Shot 2020-06-05 at 2 20 01 PM](https://user-images.githubusercontent.com/66444091/83923980-4708fd00-a738-11ea-904d-d7c573b81c9c.png)

After:
![Screen Shot 2020-06-05 at 2 19 47 PM](https://user-images.githubusercontent.com/66444091/83923995-4f613800-a738-11ea-863b-ce3488d49406.png)

