### PR TITLE
Update getting started to remove 3rd party ref.

### DIFF
--- a/website/static/getting-started.html
+++ b/website/static/getting-started.html
@@ -33,8 +33,8 @@
             <li><a href="faq.html">FAQ</a></li>
             <li><a href="community.html">Community</a></li>
             <li><a href="resources.html">Resources</a></li>
-            <li><a href="join.html">Foundation</a>
-            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a>
+            <li><a href="join.html">Foundation</a></li>
+            <li><a href="https://github.com/prestodb/presto"><img height=20 src="./img/github.svg" alt="GitHub Octocat"></a></li>
         </ul>
     </nav>
 </header>
@@ -57,7 +57,7 @@
   <h1>Getting Started tutorials provided by the community</h1>
    </p>
    <ul>
-            <li><a href="https://hub.docker.com/r/ahanaio/prestodb-sandbox">DockerHub: PrestoDB sandbox container</a> written by <a href="https://ahana.io/?utm_source=prestodb&utm_medium=website&utm_campaign=getting-started">Ahana</a>
+            <li><a href="https://hub.docker.com/r/ahanaio/prestodb-sandbox">DockerHub: PrestoDB sandbox container</a></li> 
 	<ul>
 	<ul>
 <ul>
@@ -69,16 +69,16 @@
  </ul>
    	</ul>
 
-    <li><a href="https://github.com/prestodb/f8-2019-demo">F8 2019 Classroom Demo: Getting Started with Presto</a> written by <a href="https://opensource.facebook.com/">Facebook Engineering</a></li>
+    <li><a href="https://github.com/prestodb/f8-2019-demo">F8 2019 Classroom Demo: Getting Started with Presto</a></li> 
 <ul>
 	<ul>
 <ul>
 	<ul>
-		<li> See <a href="https://www.youtube.com/watch?v=67gXN5697Vw">YouTube video</ul>
+		<li> See <a href="https://www.youtube.com/watch?v=67gXN5697Vw">YouTube video</ul></li>
    	</ul>
  </ul>
    	</ul>
-    <li><a href="https://medium.com/macoclock/installing-prestodb-on-mac-within-3-mins-84720d9b5b45">How to install on Mac in 3 min </a> written by Rishi Jain</li>
+    <li><a href="https://medium.com/macoclock/installing-prestodb-on-mac-within-3-mins-84720d9b5b45">How to install on Mac in 3 min </a> </li>
 
 
 


### PR DESCRIPTION
Per discussion in the Outreach Committee Meeting dating July 1st, it was agreed that third party content from vendors will be added to the Resources page on the website. Core documentation should not have references to vendor content. 

Once the official dockerhub for prestodb is ready, this tutorial will be moved to the Resources page.