### PR TITLE
Improve landscape embed

### DIFF
--- a/website/static/join.html
+++ b/website/static/join.html
@@ -66,15 +66,10 @@
 href="https://www.linuxfoundation.org/press-release/2019/09/facebook-uber-twitter-and-alibaba-form-presto-foundation-to-tackle-distributed-data-processing-at-scale/">joined the Linux Foundation</a>
             in September 2019.
         </p>
-        
-        <p>
-            The founding members of the Presto Foundation are: Facebook, Uber, Twitter, and Alibaba.
-        </p>
-        
-        <p>
-            The current members are: Facebook, Uber, Twitter, Alibaba, <a href="https://alluxio.io">Alluxio</a>, <a href="https://ahana.io">Ahana</a>, <a href="https://www.upsolver.com/">Upsolver</a>, and Intel.
-            <img src="./img/prestofoundationmembers.png">
-        </p>
+
+        <iframe
+src="https://landscape.prestodb.io/card-mode?category=presto-foundation-member&grouping=category&embed=yes&style=borderless&css=https://prestodb.io/static/landscape.css" frameborder="0" id="landscape" scrolling="no" style="width: 1px; min-width: 100%; opacity: 1; visibility: visible; overflow: hidden; height: 1717px;"></iframe>
+        <script src="https://landscape.openmainframeproject.org/iframeResizer.js"></script>
         </p>
 
         <h3 id="where-is-the-presto-foundation-hosted">Where is the Presto Foundation hosted?</h3>

--- a/website/static/static/landscape.css
+++ b/website/static/static/landscape.css
@@ -1,0 +1,19 @@
+.main.embed {
+  min-height: 200px;
+}
+
+h1 {
+  display: none;
+}
+
+.sh_wrapper {
+  display: none;
+}
+
+.embed .mosaic-wrap {
+  width: 20%;
+}
+
+.borderless-mode .mosaic .logo {
+  height: 100px;
+}


### PR DESCRIPTION
This PR embeds a landscape directly on the foundation page, replacing the static list of companies and logos, which had gotten out of date.