### PR TITLE
Fix display of the missing blog title

### DIFF
--- a/website/static/static/landscape.css
+++ b/website/static/static/landscape.css
@@ -2,10 +2,6 @@
   min-height: 200px;
 }
 
-h1 {
-  display: none;
-}
-
 .sh_wrapper {
   display: none;
 }


### PR DESCRIPTION
Removed the "h1" css block that's removing the blog title. Tested on laptop. Fixes https://github.com/prestodb/presto/issues/16176

![image](https://user-images.githubusercontent.com/21304668/120503654-1d34f580-c3e1-11eb-9e9c-5422c2c8a163.png)
