### PR TITLE
Add Presto + Cube tutorial

### DIFF
--- a/website/static/resources.html
+++ b/website/static/resources.html
@@ -63,6 +63,18 @@
             </dl>
         </div>
 
+        <div class="item">
+            <h4>Querying multiple data sources with Presto and Cube</h4>
+            <dl>
+                <dt>Website</dt>
+                <dd><a href="https://cube.dev/blog/category/presto" target="_blank">Presto category in Cube's blog</a></dd>
+                <dt>Maintained by</dt>
+                <dd><a href="https://cube.dev/" target="_blank">Cube</a></dd>
+                <dt>Description</dt>
+                <dd>Learn how to set up a Presto cluster, query data in AWS S3 and PostgreSQL, encapsulate metrics definitions, and deliver them to an embedded analytics application. <a href="https://cube.dev/blog/ahana-integration-querying-multiple-data-sources-with-managed-presto-and-cube" target="_blank">Read more in the blog</a>.</dd>
+            </dl>
+        </div>
+
 <h2 id="tools">Presto Management Tools</h2>
 
         <div class="item">


### PR DESCRIPTION
Hey folks 👋 Not sure about this but maybe it makes sense to have a link to this [long tutorial](https://cube.dev/blog/ahana-integration-querying-multiple-data-sources-with-managed-presto-and-cube) by @mikulskibartosz somewhere on the Presto website? WDYT?

I added it under *Resources* since there's already a *Tutorials* subsection there:
<img width="1624" alt="Screenshot 2022-06-08 at 22 44 35" src="https://user-images.githubusercontent.com/3852894/172703774-0c52c181-54d7-4830-9503-e7a6e4dd0859.png">