### PR TITLE
Updating resource group documentation with allowed name template

### DIFF
--- a/website/static/docs/0.280/admin/resource-groups.html
+++ b/website/static/docs/0.280/admin/resource-groups.html
@@ -579,7 +579,8 @@ client-provided tags associated with the query.</p></li>
 Templates allow administrators to construct resource group trees dynamically. For example, in
 the <code class="docutils literal notranslate"><span class="pre">pipeline_${USER}</span></code> group, <code class="docutils literal notranslate"><span class="pre">${USER}</span></code> will be expanded to the name of the user that submitted
 the query. <code class="docutils literal notranslate"><span class="pre">${SOURCE}</span></code> is also supported, which will be expanded to the source that submitted the
-query. You may also use custom named variables in the <code class="docutils literal notranslate"><span class="pre">source</span></code> and <code class="docutils literal notranslate"><span class="pre">user</span></code> regular expressions.</p>
+query. You may also use custom named variables in the <code class="docutils literal notranslate"><span class="pre">source</span></code> and <code class="docutils literal notranslate"><span class="pre">user</span></code> regular expressions.
+Custom named variable allow only alphabets and numbers.</p>
 <p>There are four selectors that define which queries run in which resource group:</p>
 <blockquote>
 <div><ul class="simple">
@@ -590,9 +591,9 @@ class of queries, since they are expected to be fast.</p></li>
 <li><p>The third selector matches queries from a source name that includes “pipeline”, and places them in a
 dynamically-created per-user pipeline group under the <code class="docutils literal notranslate"><span class="pre">global.pipeline</span></code> group.</p></li>
 <li><p>The fourth selector matches queries that come from BI tools (which have a source matching the regular
-expression <code class="docutils literal notranslate"><span class="pre">"jdbc#(?&lt;tool_name&gt;.*)"</span></code>), and have client provided tags that are a superset of “hi-pri”.
+expression <code class="docutils literal notranslate"><span class="pre">"jdbc#(?&lt;toolName&gt;.*)"</span></code>), and have client provided tags that are a superset of “hi-pri”.
 These are placed in a dynamically-created sub-group under the <code class="docutils literal notranslate"><span class="pre">global.pipeline.tools</span></code> group. The dynamic
-sub-group will be created based on the named variable <code class="docutils literal notranslate"><span class="pre">tool_name</span></code>, which is extracted from the in the
+sub-group will be created based on the named variable <code class="docutils literal notranslate"><span class="pre">toolName</span></code>, which is extracted from the in the
 regular expression for source. Consider a query with a source “jdbc#powerfulbi”, user “kayla”, and
 client tags “hipri” and “fast”. This query would be routed to the <code class="docutils literal notranslate"><span class="pre">global.pipeline.bi-powerfulbi.kayla</span></code>
 resource group.</p></li>
@@ -657,7 +658,7 @@ results in fairness when under contention.</p></li>
 <span class="w">              </span><span class="p">]</span>
 <span class="w">            </span><span class="p">},</span>
 <span class="w">            </span><span class="p">{</span>
-<span class="w">              </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"bi-${tool_name}"</span><span class="p">,</span>
+<span class="w">              </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"bi-${toolName}"</span><span class="p">,</span>
 <span class="w">              </span><span class="nt">"softMemoryLimit"</span><span class="p">:</span><span class="w"> </span><span class="s2">"10%"</span><span class="p">,</span>
 <span class="w">              </span><span class="nt">"hardConcurrencyLimit"</span><span class="p">:</span><span class="w"> </span><span class="mi">10</span><span class="p">,</span>
 <span class="w">              </span><span class="nt">"maxQueued"</span><span class="p">:</span><span class="w"> </span><span class="mi">100</span><span class="p">,</span>
@@ -716,9 +717,9 @@ results in fairness when under contention.</p></li>
 <span class="w">      </span><span class="nt">"group"</span><span class="p">:</span><span class="w"> </span><span class="s2">"global.pipeline.pipeline_${USER}"</span>
 <span class="w">    </span><span class="p">},</span>
 <span class="w">    </span><span class="p">{</span>
-<span class="w">      </span><span class="nt">"source"</span><span class="p">:</span><span class="w"> </span><span class="s2">"jdbc#(?&lt;tool_name&gt;.*)"</span><span class="p">,</span>
+<span class="w">      </span><span class="nt">"source"</span><span class="p">:</span><span class="w"> </span><span class="s2">"jdbc#(?&lt;toolName&gt;.*)"</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">"clientTags"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">"hipri"</span><span class="p">],</span>
-<span class="w">      </span><span class="nt">"group"</span><span class="p">:</span><span class="w"> </span><span class="s2">"global.adhoc.bi-${tool_name}.${USER}"</span>
+<span class="w">      </span><span class="nt">"group"</span><span class="p">:</span><span class="w"> </span><span class="s2">"global.adhoc.bi-${toolName}.${USER}"</span>
 <span class="w">    </span><span class="p">},</span>
 <span class="w">    </span><span class="p">{</span>
 <span class="w">      </span><span class="nt">"group"</span><span class="p">:</span><span class="w"> </span><span class="s2">"global.adhoc.other.${USER}"</span>


### PR DESCRIPTION
Resource group name only allows alphabets and numbrers but the documentation example shows special characaters (i.e. tool_name) allowed. This lead to issues when users trying to use it. As part of this PR correcting that and providing info around the restrictions with the resource group name.