### PR TITLE
Fix minor typos on 'What is Presto' static page

### DIFF
--- a/website/static/what-is-presto.html
+++ b/website/static/what-is-presto.html
@@ -174,7 +174,7 @@
                 class="blue-dot-large"></span>
             </div>
             <div class="col-12 col-md-10 my-3">
-              <h5 class="mb-0"><b>Disaggregated Coordinator (aka Fireball)</b></h5>Scale out the coordinator horiztonally and revamp
+              <h5 class="mb-0"><b>Disaggregated Coordinator (aka Fireball)</b></h5>Scale out the coordinator horizontally and revamp
               the&nbsp;RPC&nbsp;stack.<br><a
                 href="https://github.com/prestodb/presto/issues/10174" target="_blank">Github</a> | <a
                 href="https://prestodb.io/blog/2022/04/15/disggregated-coordinator">Blog</a>
@@ -209,7 +209,7 @@
           <h3 class="mb-3">One Language</h3>
           <p>Different engines for different workloads means you will have to re-platform down
             the&nbsp;road. </p>
-          <p>With Presto, you get 1 familar ANSI SQL language and 1 engine for your data analytics so you don't
+          <p>With Presto, you get 1 familiar ANSI SQL language and 1 engine for your data analytics so you don't
             need to graduate to another lakehouse engine. Presto can be used for interactive and batch
             workloads, small and large amounts of data, and scales from a few to thousands of&nbsp;users.</p>
         </div>
@@ -231,7 +231,7 @@
       <div class="row sequential-fadein align-items-center" style="max-width: 1024px; margin: 3em auto;">
         <div class="col-12 col-md-6">
           <h3 class="mb-3">Fast, Reliable &amp; Efficient</h3>
-          <p>Data infrastructure costs can explode, especially with proprietary systeems like data warehouses, as
+          <p>Data infrastructure costs can explode, especially with proprietary systems like data warehouses, as
             the data size and users workloads grow.</p>
           <p>Presto is battle-tested at Meta and Uber and can scale to meet growing data sizes and workloads. It's
             faster and more efficient than other engines because it's optimized for large numbers of small


### PR DESCRIPTION
Found a few NIT typos as I was reading through [this page](https://prestodb.io/what-is-presto.html) 🙂 