### PR TITLE
Remove gh-release job in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,3 @@ jobs:
           node-version: '10.x'
       - name: Test Build
         run: cd website && yarn install && yarn build
-  gh-release:
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
-      - name: Git config
-        run: git config --global user.email "presto-oss@users.noreply.github.com" && git config --global user.name "Presto Bot"
-      - name: Fetch credentials
-        run: echo "machine github.com login presto-oss password ${{ secrets.PRESTOOSS_PUBLISH_TOKEN }}" > ~/.netrc
-      - name: Release to GitHub Pages
-        run: cd website && yarn install && GIT_USER="presto-oss" yarn run publish-gh-pages | (head -c 32768; echo "... skipping output ..."; tail -c 32768)


### PR DESCRIPTION
The workflow automatically releases website to GitHub Pages by running `yarn run publish-gh-pages` command.
~The workflow should be deleted, because GitHub Pages is not used anymore to host the website,~
Job `gh-release` in publish workflow should be deleted, because GitHub Pages is not used anymore to host the website.